### PR TITLE
Player controller

### DIFF
--- a/client/components/containers/player/NextButton.vue
+++ b/client/components/containers/player/NextButton.vue
@@ -23,6 +23,7 @@ export default Vue.extend({
   },
   methods: {
     onClicked() {
+      this.$commit('player/SET_POSITION_MS', 0);
       this.$dispatch('player/next');
     },
   },

--- a/client/components/containers/player/PreviousButton.vue
+++ b/client/components/containers/player/PreviousButton.vue
@@ -5,7 +5,6 @@
     :disabled="isPreviousDisallowed"
     title="前の曲"
     @click="onPreivousClicked"
-    @dblclick="onPreviousDoubleClicked"
   >
     <v-icon :size="size">
       mdi-skip-previous
@@ -17,12 +16,22 @@
 import Vue from 'vue';
 import { RootState } from 'vuex';
 
+type Data = {
+  firstClicked: boolean
+}
+
 export default Vue.extend({
   props: {
     size: {
       type: Number,
       default: 28,
     },
+  },
+
+  data(): Data {
+    return {
+      firstClicked: false,
+    };
   },
 
   computed: {
@@ -36,15 +45,19 @@ export default Vue.extend({
 
   methods: {
     onPreivousClicked() {
-      // position が 0:01 未満のときに前の曲に戻る
-      if (this.position < 1000) {
+      this.$commit('player/SET_POSITION_MS', 0);
+      // 初めにクリックされてから1秒以内に再度クリックされたら前の曲に戻る
+      if (this.firstClicked) {
         this.$dispatch('player/previous');
       } else {
+        this.firstClicked = true;
+        const interval = 1000;
+        setTimeout(() => {
+          this.firstClicked = false;
+        }, interval);
+
         this.$dispatch('player/seek', 0);
       }
-    },
-    onPreviousDoubleClicked() {
-      this.$dispatch('player/previous');
     },
   },
 });

--- a/client/components/containers/player/SeekBar.vue
+++ b/client/components/containers/player/SeekBar.vue
@@ -8,6 +8,7 @@
       :color="seekbarColor"
       :max="maxMs"
       :class="$style.SeekBar__slider"
+      @mousedown="onMouseDown"
       @change="onChange"
     />
 
@@ -99,11 +100,14 @@ export default Vue.extend({
   },
 
   methods: {
+    onMouseDown() {
+      this.clearInterval();
+    },
     onChange(positionMs: number) {
       // setter の後に実行させたい
       setTimeout(() => {
-        console.log('onchange');
         this.$dispatch('player/seek', positionMs);
+        this.updatePosition();
       }, 0);
     },
     updatePosition() {
@@ -113,13 +117,14 @@ export default Vue.extend({
       }
 
       this.updateInterval = setInterval(() => {
-        // positionMs が durationMs より大きい値になった場合は自動的に 0 に戻る
         this.$commit('player/ADD_POSITION_MS', intervalMs);
       }, intervalMs);
     },
     clearInterval() {
-      if (this.updateInterval != null) clearInterval(this.updateInterval);
-      this.updateInterval = undefined;
+      if (this.updateInterval != null) {
+        clearInterval(this.updateInterval);
+        this.updateInterval = undefined;
+      }
     },
   },
 });

--- a/client/components/containers/player/SeekBar.vue
+++ b/client/components/containers/player/SeekBar.vue
@@ -113,11 +113,8 @@ export default Vue.extend({
     },
     onChange(positionMs: number) {
       this.$commit('player/SET_POSITION_MS', positionMs);
-      // setter の後に実行させたい
-      setTimeout(() => {
-        this.$dispatch('player/seek', positionMs);
-        this.updatePosition();
-      }, 0);
+      this.$dispatch('player/seek', positionMs);
+      this.updatePosition();
     },
     updatePosition() {
       const intervalMs = 500;

--- a/client/components/globals/Footer.vue
+++ b/client/components/globals/Footer.vue
@@ -62,9 +62,7 @@
           </v-btn>
         </div>
 
-        <VolumeSlider
-          @on-changed="onVolumuChanged"
-        />
+        <VolumeSlider />
       </div>
     </div>
   </v-footer>
@@ -81,7 +79,7 @@ import FavoriteButton, { On as OnFavorite } from '~/components/parts/button/Favo
 import SeekBar from '~/components/containers/player/SeekBar.vue';
 import MediaControllersWrapper from '~/components/parts/wrapper/MediaControllersWrapper.vue';
 import DeviceSelectMenuButton from '~/components/containers/player/DeviceSelectMenuButton.vue';
-import VolumeSlider, { On as OnVolume } from '~/components/containers/player/VolumeSlider.vue';
+import VolumeSlider from '~/components/containers/player/VolumeSlider.vue';
 import { FOOTER_BACKGROUND_COLOR } from '~/variables';
 
 type Data = {
@@ -157,9 +155,6 @@ export default Vue.extend({
             this.$toast.show('error', err.message);
           });
       }
-    },
-    onVolumuChanged(volumePercent: OnVolume['on-changed']) {
-      this.$dispatch('player/volume', { volumePercent });
     },
   },
 });

--- a/client/store/player/mutations.ts
+++ b/client/store/player/mutations.ts
@@ -18,7 +18,6 @@ export type PlayerMutations = {
   SET_IS_PLAYING: boolean
   SET_CONTEXT_URI: string | undefined
   SET_POSITION_MS: number
-  ADD_POSITION_MS: number
   SET_DURATION_MS: number
   SET_IS_SHUFFLED: boolean
   SET_REPEAT_MODE: 0 | 1 | 2
@@ -41,7 +40,6 @@ export type RootMutations = {
   ['player/SET_IS_PLAYING']: PlayerMutations['SET_IS_PLAYING']
   ['player/SET_CONTEXT_URI']: PlayerMutations['SET_CONTEXT_URI']
   ['player/SET_POSITION_MS']: PlayerMutations['SET_POSITION_MS']
-  ['player/ADD_POSITION_MS']: PlayerMutations['ADD_POSITION_MS']
   ['player/SET_DURATION_MS']: PlayerMutations['SET_DURATION_MS']
   ['player/SET_IS_SHUFFLED']: PlayerMutations['SET_IS_SHUFFLED']
   ['player/SET_REPEAT_MODE']: PlayerMutations['SET_REPEAT_MODE']
@@ -114,10 +112,6 @@ const mutations: Mutations<PlayerState, PlayerMutations> = {
 
   SET_POSITION_MS(state, positionMs) {
     state.positionMs = positionMs;
-  },
-
-  ADD_POSITION_MS(state, positionMs) {
-    state.positionMs += positionMs;
   },
 
   SET_DURATION_MS(state, durationMs) {

--- a/utils/mssTime.ts
+++ b/utils/mssTime.ts
@@ -1,0 +1,7 @@
+export const mssTime = (timeMs: number): string => {
+  const timeSeconds = timeMs / 1000;
+  const minutes = Math.floor(timeSeconds / 60);
+  const seconds = Math.floor(timeSeconds - 60 * minutes);
+
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};


### PR DESCRIPTION
- close #84 
- close #86
- close #88 
- close #94 
- シークバー、ボリュームのスライダーのカクつきを改善
   - スライダーをぐりぐりしてる時はシークバーを進めない
   - ローカルステートで管理
   - 値変わった時にストアと通信 (`subscribe`で変更を受け付ける)
- 前後の曲に行くときの動きカイゼン
