### PR TITLE
他のデバイスを操作できるようにする

### DIFF
--- a/client/components/containers/player/DeviceSelectMenu.vue
+++ b/client/components/containers/player/DeviceSelectMenu.vue
@@ -96,7 +96,7 @@ export default Vue.extend({
 
   computed: {
     deviceButtonColor(): string | undefined {
-      return this.$getters()['player/isTheAppPlaying']
+      return this.$getters()['player/isThisAppPlaying']
         ? 'active-icon'
         : undefined;
     },

--- a/client/components/containers/player/DeviceSelectMenu.vue
+++ b/client/components/containers/player/DeviceSelectMenu.vue
@@ -102,9 +102,9 @@ export default Vue.extend({
     },
     deviceItemList(): DeviceInfo[] {
       // @todo any[] で推論されてしまう
-      const activeDeviceList = this.$state().player.activeDeviceList as SpotifyAPI.Device[];
+      const deviceList = this.$state().player.deviceList as SpotifyAPI.Device[];
 
-      return activeDeviceList.map((device) => ({
+      return deviceList.map((device) => ({
         id: device.id ?? undefined,
         type: device.type,
         isActive: device.is_active,
@@ -126,6 +126,8 @@ export default Vue.extend({
     onItemClicked(deviceId: OnItem['on-clicked']) {
       if (deviceId != null) {
         this.$dispatch('player/transferPlayback', { deviceId });
+      } else {
+        this.$toast.show('error', 'デバイスを変更できません。');
       }
     },
   },

--- a/client/components/containers/player/DeviceSelectMenu.vue
+++ b/client/components/containers/player/DeviceSelectMenu.vue
@@ -23,46 +23,45 @@
       </v-btn>
     </template>
 
-    <v-card :elevation="12">
-      <v-list
-        dense
-        subheader
-        :color="MENU_BACKGROUND_COLOR"
-        :class="$style.DeviceSelectMenu"
-      >
-        <div :class="$style.DeviceSelectMenu__header">
-          <v-subheader>
-            デバイスを選択
-          </v-subheader>
+    <v-list
+      dense
+      subheader
+      :elevation="12"
+      :color="MENU_BACKGROUND_COLOR"
+      :class="$style.DeviceSelectMenu"
+    >
+      <div :class="$style.DeviceSelectMenu__header">
+        <v-subheader>
+          デバイスを選択
+        </v-subheader>
 
-          <v-btn
-            icon
-            small
-            :loading="isRefreshingDeviceList"
-            title="デバイスの一覧を更新"
-            @click.stop="onUpdateButtonClicked"
-          >
-            <v-icon>
-              mdi-refresh
-            </v-icon>
-          </v-btn>
-        </div>
-
-        <v-divider />
-
-        <v-list-item-group
-          :class="$style.DeviceSelectMenu__wrapper"
-          class="g-custom-scroll-bar"
+        <v-btn
+          icon
+          small
+          :loading="isRefreshingDeviceList"
+          title="デバイスの一覧を更新"
+          @click.stop="onUpdateButtonClicked"
         >
-          <DeviceSelectMenuItem
-            v-for="(device, index) in deviceItemList"
-            :key="`${device.id}-${index}`"
-            v-bind="device"
-            @on-clicked="onItemClicked"
-          />
-        </v-list-item-group>
-      </v-list>
-    </v-card>
+          <v-icon>
+            mdi-refresh
+          </v-icon>
+        </v-btn>
+      </div>
+
+      <v-divider />
+
+      <v-list-item-group
+        :class="$style.DeviceSelectMenu__wrapper"
+        class="g-custom-scroll-bar"
+      >
+        <DeviceSelectMenuItem
+          v-for="(device, index) in deviceItemList"
+          :key="`${device.id}-${index}`"
+          v-bind="device"
+          @on-clicked="onItemClicked"
+        />
+      </v-list-item-group>
+    </v-list>
   </v-menu>
 </template>
 
@@ -108,6 +107,7 @@ export default Vue.extend({
         id: device.id ?? undefined,
         type: device.type,
         isActive: device.is_active,
+        disabled: device.id == null,
         title: device.is_active ? '再生中のデバイス' : device.name,
         subtitle: device.is_active ? device.name : 'Spotify Connect',
       }));

--- a/client/components/globals/Footer.vue
+++ b/client/components/globals/Footer.vue
@@ -138,9 +138,8 @@ export default Vue.extend({
   },
 
   // player を初期化してからアクティブなデバイスを取得する
-  async mounted() {
-    await this.$dispatch('player/initPlayer');
-    this.$dispatch('player/getActiveDeviceList');
+  mounted() {
+    this.$dispatch('player/initPlayer');
   },
 
   methods: {

--- a/client/components/parts/list/DeviceSelectMenuItem.vue
+++ b/client/components/parts/list/DeviceSelectMenuItem.vue
@@ -2,13 +2,14 @@
   <v-list-item
     dense
     two-line
-    :disabled="id == null"
+    :disabled="disabled"
+    :inactive="disabled"
     @click="onItemClicked"
   >
     <v-list-item-avatar>
       <v-icon
         :size="32"
-        :color="isActive ? 'active' : undefined"
+        :color="disabled ? 'inactive' : isActive ? 'active' : undefined"
       >
         {{ icon }}
       </v-icon>
@@ -16,21 +17,23 @@
 
     <v-list-item-content>
       <v-list-item-title
-        :class="[
-          isActive ? 'active--text' : undefined,
-        ]"
+        :class="{
+          'active--text': isActive,
+          'inactive--text': disabled,
+        }"
       >
         {{ title }}
       </v-list-item-title>
 
       <v-list-item-subtitle
-        :class="[
-          isActive ? 'active--text' : undefined,
-        ]"
+        :class="{
+          'active--text': isActive,
+          'inactive--text': disabled,
+        }"
       >
         <v-icon
           v-show="isActive"
-          :color="isActive ? 'active' : undefined"
+          :color="disabled ? 'inactive' : isActive ? 'active' : undefined"
           :size="16"
         >
           mdi-volume-high
@@ -81,6 +84,7 @@ export type DeviceInfo = {
   id: string | undefined
   type: string
   isActive: boolean
+  disabled: boolean
   title: string
   subtitle: string
 }
@@ -106,6 +110,10 @@ export default Vue.extend({
       required: true,
     },
     isActive: {
+      type: Boolean,
+      required: true,
+    },
+    disabled: {
       type: Boolean,
       required: true,
     },

--- a/client/plugins/spotify/endpoints/player/getCurrentPlayback.ts
+++ b/client/plugins/spotify/endpoints/player/getCurrentPlayback.ts
@@ -1,14 +1,14 @@
 import { Context } from '@nuxt/types';
 import { SpotifyAPI } from '~~/types';
 
-export const getCurrentlyPlaying = (context: Context) => {
+export const getCurrentPlayback = (context: Context) => {
   const { app } = context;
 
   return ({ market, additionalTypeList }: {
     market?: SpotifyAPI.Country
     additionalTypeList?: Array<'track' | 'episode'>
-  }): Promise<SpotifyAPI.Player.CurrentlyPlaying | undefined> => {
-    const request = app.$spotifyApi.$get('/me/player/currently-playing', {
+  }): Promise<SpotifyAPI.Player.CurrentPlayback | undefined> => {
+    const request = app.$spotifyApi.$get('/me/player', {
       params: {
         market,
         additional_types: additionalTypeList?.join(','),

--- a/client/plugins/spotify/endpoints/player/getRecentlyPlayed.ts
+++ b/client/plugins/spotify/endpoints/player/getRecentlyPlayed.ts
@@ -7,24 +7,20 @@ export const getRecentlyPlayed = (context: Context) => {
   /**
    * after と before はどちらか一方をミリ秒で指定する
    */
-  return ({
-    limit = 20,
-    after,
-    before,
-  }: {
+  return (params?: {
     limit?: number // 1 ~ 50 まで指定できる
     after?: number
     before?: number
   }): Promise<SpotifyAPI.Player.RecentlyPlayed | undefined> => {
-    if (limit < 1 || limit > 50) {
+    const limit = params?.limit;
+    if (limit != null && (limit < 1 || limit > 50)) {
       throw new Error(`limit は1 ~ 50までしか指定できませんが、${limit}と指定されました。`);
     }
 
     return app.$spotifyApi.$get('/me/player/recently-played', {
       params: {
-        limit,
-        after,
-        before,
+        limit: 20,
+        ...params,
       },
     }).catch((err: Error) => {
       console.error({ err });

--- a/client/plugins/spotify/endpoints/player/index.ts
+++ b/client/plugins/spotify/endpoints/player/index.ts
@@ -2,7 +2,7 @@ import { Context } from '@nuxt/types';
 
 import { addItemToQueue } from './addItemToQueue';
 import { getActiveDeviceList } from './getActiveDeviceList';
-import { getCurrentlyPlaying } from './getCurrentlyPlaying';
+import { getCurrentPlayback } from './getCurrentPlayback';
 import { getRecentlyPlayed } from './getRecentlyPlayed';
 import { next } from './next';
 import { pause } from './pause';
@@ -17,7 +17,7 @@ import { transferPlayback } from './transferPlayback';
 export const player = (context: Context) => ({
   addItemToQueue: addItemToQueue(context),
   getActiveDeviceList: getActiveDeviceList(context),
-  getCurrentlyPlaying: getCurrentlyPlaying(context),
+  getCurrentPlayback: getCurrentPlayback(context),
   getRecentlyPlayed: getRecentlyPlayed(context),
   next: next(context),
   pause: pause(context),

--- a/client/plugins/spotify/endpoints/player/next.ts
+++ b/client/plugins/spotify/endpoints/player/next.ts
@@ -3,7 +3,7 @@ import { Context } from '@nuxt/types';
 export const next = (context: Context) => {
   const { app } = context;
 
-  return ({ deviceId }: { deviceId: string | undefined }): Promise<void> => {
+  return ({ deviceId }: { deviceId?: string | undefined }): Promise<void> => {
     const request = app.$spotifyApi.$post('/me/player/next', undefined, {
       params: { device_id: deviceId },
     }).catch((err: Error) => {

--- a/client/plugins/spotify/endpoints/player/next.ts
+++ b/client/plugins/spotify/endpoints/player/next.ts
@@ -3,9 +3,9 @@ import { Context } from '@nuxt/types';
 export const next = (context: Context) => {
   const { app } = context;
 
-  return ({ deviceId }: { deviceId?: string | undefined }): Promise<void> => {
+  return (params?: { deviceId?: string | undefined }): Promise<void> => {
     const request = app.$spotifyApi.$post('/me/player/next', undefined, {
-      params: { device_id: deviceId },
+      params,
     }).catch((err: Error) => {
       console.error({ err });
       throw new Error(err.message);

--- a/client/plugins/spotify/endpoints/player/pause.ts
+++ b/client/plugins/spotify/endpoints/player/pause.ts
@@ -8,10 +8,7 @@ export const pause = (context: Context) => {
     isInitializing = false,
   }: {
     deviceId?: string | undefined
-    isInitializing?: false
-  } | {
-    deviceId?: undefined
-    isInitializing: true
+    isInitializing?: boolean
   }): Promise<void> => {
     const request = app.$spotifyApi.$put('/me/player/pause', undefined, {
       params: {

--- a/client/plugins/spotify/endpoints/player/pause.ts
+++ b/client/plugins/spotify/endpoints/player/pause.ts
@@ -7,7 +7,7 @@ export const pause = (context: Context) => {
     deviceId,
     isInitializing = false,
   }: {
-    deviceId: string | undefined
+    deviceId?: string | undefined
     isInitializing?: false
   } | {
     deviceId?: undefined

--- a/client/plugins/spotify/endpoints/player/play.ts
+++ b/client/plugins/spotify/endpoints/player/play.ts
@@ -14,7 +14,7 @@ export const play = (context: Context) => {
     offset,
     positionMs,
   }: {
-    deviceId: string | undefined
+    deviceId?: string | undefined
     contextUri?: string
     trackUriList?: string[]
     offset?: { uri: string } | { position: number }

--- a/client/plugins/spotify/endpoints/player/previous.ts
+++ b/client/plugins/spotify/endpoints/player/previous.ts
@@ -10,6 +10,7 @@ export const previous = (context: Context) => {
       },
     }).catch((err: Error) => {
       console.error({ err });
+      throw new Error(err.message);
     });
 
     return request;

--- a/client/plugins/spotify/endpoints/player/previous.ts
+++ b/client/plugins/spotify/endpoints/player/previous.ts
@@ -3,11 +3,9 @@ import { Context } from '@nuxt/types';
 export const previous = (context: Context) => {
   const { app } = context;
 
-  return ({ deviceId }: { deviceId?: string | undefined }): Promise<void> => {
+  return (params?: { deviceId?: string | undefined }): Promise<void> => {
     const request = app.$spotifyApi.$post('/me/player/previous', undefined, {
-      params: {
-        device_id: deviceId,
-      },
+      params,
     }).catch((err: Error) => {
       console.error({ err });
       throw new Error(err.message);

--- a/client/plugins/spotify/endpoints/player/previous.ts
+++ b/client/plugins/spotify/endpoints/player/previous.ts
@@ -3,7 +3,7 @@ import { Context } from '@nuxt/types';
 export const previous = (context: Context) => {
   const { app } = context;
 
-  return ({ deviceId }: { deviceId: string | undefined }): Promise<void> => {
+  return ({ deviceId }: { deviceId?: string | undefined }): Promise<void> => {
     const request = app.$spotifyApi.$post('/me/player/previous', undefined, {
       params: {
         device_id: deviceId,

--- a/client/plugins/spotify/endpoints/player/repeat.ts
+++ b/client/plugins/spotify/endpoints/player/repeat.ts
@@ -9,7 +9,7 @@ export const repeat = (context: Context) => {
     deviceId,
     state,
   }: {
-    deviceId: string | undefined
+    deviceId?: string | undefined
     state: SpotifyAPI.RepeatState
   }): Promise<void> => {
     const request = app.$spotifyApi.$put('/me/player/repeat', undefined, {

--- a/client/plugins/spotify/endpoints/player/repeat.ts
+++ b/client/plugins/spotify/endpoints/player/repeat.ts
@@ -19,6 +19,7 @@ export const repeat = (context: Context) => {
       },
     }).catch((err: Error) => {
       console.error({ err });
+      throw new Error(err.message);
     });
 
     return request;

--- a/client/plugins/spotify/endpoints/player/seek.ts
+++ b/client/plugins/spotify/endpoints/player/seek.ts
@@ -7,7 +7,7 @@ export const seek = (context: Context) => {
     deviceId,
     positionMs,
   }: {
-    deviceId: string | undefined
+    deviceId?: string | undefined
     positionMs: number
   }): Promise<void> => app.$spotifyApi.$put('/me/player/seek', undefined, {
     params: {

--- a/client/plugins/spotify/endpoints/player/shuffle.ts
+++ b/client/plugins/spotify/endpoints/player/shuffle.ts
@@ -7,7 +7,7 @@ export const shuffle = (context: Context) => {
     deviceId,
     state,
   }: {
-    deviceId: string | undefined
+    deviceId?: string | undefined
     state: boolean
   }): Promise<void> => {
     const request = app.$spotifyApi.$put('/me/player/shuffle', undefined, {

--- a/client/plugins/spotify/endpoints/player/transferPlayback.ts
+++ b/client/plugins/spotify/endpoints/player/transferPlayback.ts
@@ -12,6 +12,7 @@ export const transferPlayback = (context: Context) => {
       play,
     }).catch((err: Error) => {
       console.error({ err });
+      throw new Error(err.message);
     });
 
     return request;

--- a/client/plugins/spotify/endpoints/player/transferPlayback.ts
+++ b/client/plugins/spotify/endpoints/player/transferPlayback.ts
@@ -3,6 +3,9 @@ import { Context } from '@nuxt/types';
 export const transferPlayback = (context: Context) => {
   const { app } = context;
 
+  /**
+   * play === false の場合は現在の再生状態を維持
+   */
   return ({ deviceId, play }: {
     deviceId: string
     play: boolean

--- a/client/plugins/spotify/endpoints/player/volume.ts
+++ b/client/plugins/spotify/endpoints/player/volume.ts
@@ -7,7 +7,7 @@ export const volume = (context: Context) => {
     deviceId,
     volumePercent,
   }: {
-    deviceId: string | undefined
+    deviceId?: string | undefined
     volumePercent: number
   }): Promise<void> => {
     if (volumePercent < 0 || volumePercent > 100) {

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -203,16 +203,15 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
       player.addListener('ready', async ({ device_id }) => {
         commit('SET_DEVICE_ID', device_id);
 
-        // 再生中でない場合
-        if (!this.$state().player.isPlaying) {
-          // デバイスをアクティブにする前に再生を止めないとアクティブにした後勝手に再生される可能性があるらしい
-          await dispatch('pause', { isInitializing: true });
-        }
+        await dispatch('getActiveDeviceList');
 
-        await dispatch('transferPlayback', {
-          deviceId: device_id,
-          play: false,
-        });
+        const activeDevice = this.$getters()['player/activeDevice'];
+        if (activeDevice == null) {
+          await dispatch('transferPlayback', {
+            deviceId: device_id,
+            play: false,
+          });
+        }
 
         console.log('Ready with this device 🎉');
       });

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -12,7 +12,6 @@ export type PlayerActions = {
   transferPlayback: ({ deviceId, play }: {
     deviceId: string
     play?: boolean
-    force?: boolean
   }) => Promise<void>
   reconnectDevice: () => Promise<void>
   getActiveDeviceList: () => Promise<void>
@@ -265,10 +264,8 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
     commit('SET_IS_MUTED', false);
   },
 
-  async transferPlayback({ state, commit, dispatch }, { deviceId, play, force }) {
-    const { activeDeviceId, isPlaying, deviceList } = state;
-    // force === true の場合は強制的にリクエスト
-    if (!force && deviceId === activeDeviceId) return;
+  async transferPlayback({ state, commit, dispatch }, { deviceId, play }) {
+    const { isPlaying, deviceList } = state;
 
     // play が指定されなかった場合は、現在の状態を維持
     await this.$spotify.player.transferPlayback({
@@ -313,10 +310,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
 
     commit('SET_ACTIVE_DEVICE_ID', deviceId);
 
-    await dispatch('transferPlayback', {
-      deviceId,
-      force: true,
-    });
+    await dispatch('transferPlayback', { deviceId });
   },
 
   async getActiveDeviceList({ commit }) {

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -214,14 +214,6 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
           play: false,
         });
 
-        // volme は 0 から 1
-        const volume = await player.getVolume().catch((err: Error) => {
-          console.error({ err });
-          return 1;
-        });
-
-        commit('SET_VOLUME_PERCENT', { volumePercent: volume * 100 });
-
         console.log('Ready with this device 🎉');
       });
 
@@ -320,6 +312,13 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
     commit('SET_DEVICE_LIST', deviceList);
 
     const activeDevice = deviceList.find((device) => device.is_active);
+
+    commit('SET_VOLUME_PERCENT', {
+      volumePercent: activeDevice != null
+        ? activeDevice.volume_percent
+        : 100,
+    });
+
     if (activeDevice?.id != null) {
       commit('SET_ACTIVE_DEVICE_ID', activeDevice.id);
     }

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -167,6 +167,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
         const disallowKeys = Object.keys(disallows) as Array<keyof typeof disallows>;
         const disallowList = disallowKeys.filter((key) => disallows[key]);
 
+        // currentTrack を変更する前に行う
         const lastTrackId = this.$state().player.trackId;
         const trackId = currentTrack.id;
         // trackId 変わったときだけチェック
@@ -378,7 +379,6 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
           artists: item.artists,
         }
         : undefined;
-      commit('SET_CURRENT_TRACK', track);
 
       if (track == null) {
         // アイテムが取得できない場合は3回まで1秒ごとにリトライ
@@ -391,7 +391,17 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
 
         commit('RESET_RETRY_COUNTS_OF_GET_CURRENT_PLAYBACK');
         this.$toast.show('warning', '再生中のアイテムの情報を取得できませんでした。');
+      } else {
+        // currentTrack を変更する前に行う
+        const lastTrackId = this.$state().player.trackId;
+        const trackId = track.id;
+        // trackId 変わったときだけチェック
+        if (trackId != null && trackId !== lastTrackId) {
+          dispatch('checkTrackSavedState', trackId);
+        }
       }
+
+      commit('SET_CURRENT_TRACK', track);
 
       // 曲を再生しきって 500ms と 20s で早いほう経った後再取得
       const interval = Math.min(this.$getters()['player/remainingTimeMs'] + 500, 20 * 1000);

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -314,7 +314,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
     commit('SET_CUSTOM_TRACK_URI_LIST', undefined);
   },
 
-  getCurrentPlayback({ commit, rootGetters }, timeout) {
+  getCurrentPlayback({ commit, dispatch, rootGetters }, timeout) {
     const handler = async () => {
       // このデバイスで再生中の場合は playback-sdk から取得する
       if (this.$getters()['player/isThisAppPlaying']) return;
@@ -335,10 +335,14 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
         commit('SET_POSITION_MS', currentPlayback.progress_ms ?? 0);
         commit('SET_DURATION_MS', currentPlayback.item?.duration_ms ?? 0);
         commit('SET_IS_SHUFFLED', currentPlayback.shuffle_state === 'on');
-        commit('SET_ACTIVE_DEVICE_ID', currentPlayback.device.id ?? undefined);
         commit('SET_NEXT_TRACK_LIST', []);
         commit('SET_PREVIOUS_TRACK_LIST', []);
         commit('SET_DISALLOW_LIST', disallowList);
+
+        // アクティブなデバイスが異なる場合はデバイス一覧を取得し直す
+        if (currentPlayback.device.id !== this.$getters()['player/activeDevice']?.id) {
+          dispatch('getActiveDeviceList');
+        }
 
         // @todo episode 再生中だと null になる
         const track: Spotify.Track | undefined = item != null && item.type === 'track'

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -259,7 +259,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
   async transferPlayback({ state, commit, dispatch }, { deviceId, play }) {
     const { isPlaying, deviceList } = state;
 
-    // play が指定されなかった場合は、現在の状態を維持
+    // play が指定されなかった場合は、アプリ内のの状態を維持し、false が指定された場合は現在の状態を維持
     await this.$spotify.player.transferPlayback({
       deviceId,
       play: play != null

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -318,13 +318,13 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
     });
   },
 
-  async getActiveDeviceList({ state, commit }) {
+  async getActiveDeviceList({ commit }) {
     const { devices } = await this.$spotify.player.getActiveDeviceList();
     const deviceList = devices ?? [];
 
     commit('SET_DEVICE_LIST', deviceList);
 
-    const activeDevice = deviceList.find((device) => device.id === state.deviceId);
+    const activeDevice = deviceList.find((device) => device.is_active);
     if (activeDevice?.id != null) {
       commit('SET_ACTIVE_DEVICE_ID', activeDevice.id);
     }

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -216,13 +216,10 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
         });
 
         // volme は 0 から 1
-        const [volume] = await Promise.all([
-          player.getVolume().catch((err: Error) => {
-            console.error({ err });
-            return 1;
-          }),
-          dispatch('getActiveDeviceList'),
-        ] as const);
+        const volume = await player.getVolume().catch((err: Error) => {
+          console.error({ err });
+          return 1;
+        });
 
         commit('SET_VOLUME_PERCENT', { volumePercent: volume * 100 });
 

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -344,7 +344,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
   },
 
   async getRecentlyPlayed({ commit }) {
-    const recentlyPlayed = await this.$spotify.player.getRecentlyPlayed({});
+    const recentlyPlayed = await this.$spotify.player.getRecentlyPlayed();
 
     commit('SET_RECENTLY_PLAYED', recentlyPlayed);
   },
@@ -422,7 +422,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
   },
 
   async next() {
-    await this.$spotify.player.next({})
+    await this.$spotify.player.next()
       .catch((err: Error) => {
         console.error({ err });
         this.$toast.show('error', 'エラーが発生し、次の曲を再生できません。');
@@ -430,7 +430,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
   },
 
   async previous() {
-    await this.$spotify.player.previous({})
+    await this.$spotify.player.previous()
       .catch((err: Error) => {
         console.error({ err });
         this.$toast.show('error', 'エラーが発生し、前の曲を再生できません。');

--- a/client/store/player/getters.ts
+++ b/client/store/player/getters.ts
@@ -9,10 +9,10 @@ import { SpotifyAPI, App } from '~~/types';
 
 export type PlayerGetters = {
   isPlayerConnected: boolean
-  activeDevice: SpotifyAPI.Device | null
+  activeDevice: SpotifyAPI.Device | undefined
   isThisAppPlaying: boolean
   trackQueue: (artworkSize?: number) => App.TrackQueueInfo[]
-  releaseId: string | null
+  releaseId: string | undefined
   artworkSrc: (minSize?: number) => string | undefined
   hasTrack: boolean
   isTrackSet: (trackId: string) => boolean
@@ -54,7 +54,7 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
     const activeDevice = state.deviceList?.find((device) => device.is_active);
     return activeDevice != null
       ? activeDevice
-      : null;
+      : undefined;
   },
 
   isThisAppPlaying(state, getters) {
@@ -95,7 +95,7 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
     // 最後の ":" 以降を取り出す
     return state.releaseUri != null
       ? convertUriToId(state.releaseUri)
-      : null;
+      : undefined;
   },
 
   artworkSrc(state) {

--- a/client/store/player/getters.ts
+++ b/client/store/player/getters.ts
@@ -58,7 +58,7 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
   },
 
   isThisAppPlaying(state, getters) {
-    return getters.activeDevice?.id === state.activeDeviceId;
+    return getters.activeDevice?.id === state.deviceId;
   },
 
   trackQueue(state, getters) {

--- a/client/store/player/getters.ts
+++ b/client/store/player/getters.ts
@@ -1,7 +1,7 @@
 import { Getters } from 'vuex';
 
 import { PlayerState } from './state';
-import { REPEAT_STATE_LIST, APP_NAME, TRACK_LIST_ARTWORK_SIZE } from '~/variables';
+import { REPEAT_STATE_LIST, TRACK_LIST_ARTWORK_SIZE } from '~/variables';
 import { getImageSrc } from '~/scripts/converter/getImageSrc';
 import { convertTrackForQueue } from '~/scripts/converter/convertTrackForQueue';
 import { convertUriToId } from '~/scripts/converter/convertUriToId';
@@ -10,7 +10,7 @@ import { SpotifyAPI, App } from '~~/types';
 export type PlayerGetters = {
   isPlayerConnected: boolean
   activeDevice: SpotifyAPI.Device | null
-  isTheAppPlaying: boolean
+  isThisAppPlaying: boolean
   trackQueue: (artworkSize?: number) => App.TrackQueueInfo[]
   releaseId: string | null
   artworkSrc: (minSize?: number) => string | undefined
@@ -29,7 +29,7 @@ export type PlayerGetters = {
 export type RootGetters = {
   ['player/isPlayerConnected']: PlayerGetters['isPlayerConnected']
   ['player/activeDevice']: PlayerGetters['activeDevice']
-  ['player/isTheAppPlaying']: PlayerGetters['isTheAppPlaying']
+  ['player/isThisAppPlaying']: PlayerGetters['isThisAppPlaying']
   ['player/trackQueue']: PlayerGetters['trackQueue']
   ['player/releaseId']: PlayerGetters['releaseId']
   ['player/artworkSrc']: PlayerGetters['artworkSrc']
@@ -57,8 +57,8 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
       : null;
   },
 
-  isTheAppPlaying(_state, getters) {
-    return getters.activeDevice?.name === APP_NAME;
+  isThisAppPlaying(state, getters) {
+    return getters.activeDevice?.id === state.activeDeviceId;
   },
 
   trackQueue(state, getters) {
@@ -122,11 +122,11 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
     return state.contextUri ?? state.customContextUri;
   },
 
+  /**
+   * uri を指定
+   * アーティストページのトラックリストやコレクションから再生すると customContextUri に uri が保持される
+   */
   isContextSet(_, getters) {
-    /**
-     * uri を指定
-     * アーティストページのトラックリストやコレクションから再生すると customContextUri に uri が保持される
-     */
     return (uri) => uri != null && (getters.contextUri === uri);
   },
 

--- a/client/store/player/getters.ts
+++ b/client/store/player/getters.ts
@@ -51,9 +51,9 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
   },
 
   activeDevice(state) {
-    const activeDevice = state.deviceList?.filter((device) => device.is_active);
-    return activeDevice != null && activeDevice.length > 0
-      ? activeDevice[0]
+    const activeDevice = state.deviceList?.find((device) => device.is_active);
+    return activeDevice != null
+      ? activeDevice
       : null;
   },
 

--- a/client/store/player/getters.ts
+++ b/client/store/player/getters.ts
@@ -51,7 +51,7 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
   },
 
   activeDevice(state) {
-    const activeDevice = state.activeDeviceList?.filter((device) => device.is_active);
+    const activeDevice = state.deviceList?.filter((device) => device.is_active);
     return activeDevice != null && activeDevice.length > 0
       ? activeDevice[0]
       : null;

--- a/client/store/player/getters.ts
+++ b/client/store/player/getters.ts
@@ -18,6 +18,7 @@ export type PlayerGetters = {
   isTrackSet: (trackId: string) => boolean
   contextUri: string | undefined
   isContextSet: (uri: string | undefined) => boolean
+  remainingTimeMs: number
   repeatState: SpotifyAPI.RepeatState | undefined
   isPreviousDisallowed: boolean
   isShuffleDisallowed: boolean
@@ -37,6 +38,7 @@ export type RootGetters = {
   ['player/isTrackSet']: PlayerGetters['isTrackSet']
   ['player/contextUri']: PlayerGetters['contextUri']
   ['player/isContextSet']: PlayerGetters['isContextSet']
+  ['player/remainingTimeMs']: PlayerGetters['remainingTimeMs']
   ['player/repeatState']: PlayerGetters['repeatState']
   ['player/isPreviousDisallowed']: PlayerGetters['isPreviousDisallowed']
   ['player/isShuffleDisallowed']: PlayerGetters['isShuffleDisallowed']
@@ -132,6 +134,10 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
 
   isShuffleDisallowed(state) {
     return state.disallowList.some((disallow) => disallow.includes('shuffle'));
+  },
+
+  remainingTimeMs(state) {
+    return Math.max(state.durationMs - state.positionMs, 0);
   },
 
   repeatState(state) {

--- a/client/store/player/mutations.ts
+++ b/client/store/player/mutations.ts
@@ -11,6 +11,7 @@ export type PlayerMutations = {
   SET_CUSTOM_CONTEXT_URI: string | undefined
   SET_CUSTOM_TRACK_URI_LIST: string[] | undefined
   SET_RECENTLY_PLAYED: SpotifyAPI.Player.RecentlyPlayed | undefined
+  SET_GET_CURRENT_PLAYBACK_TIMER_ID: ReturnType<typeof setTimeout> | number | undefined
   SET_CURRENT_TRACK: Spotify.Track | undefined
   SET_NEXT_TRACK_LIST: Spotify.Track[]
   SET_PREVIOUS_TRACK_LIST: Spotify.Track[]
@@ -33,6 +34,7 @@ export type RootMutations = {
   ['player/SET_DEVICE_LIST']: PlayerMutations['SET_DEVICE_LIST']
   ['player/SET_CUSTOM_CONTEXT_URI']: PlayerMutations['SET_CUSTOM_CONTEXT_URI']
   ['player/SET_CUSTOM_TRACK_URI_LIST']: PlayerMutations['SET_CUSTOM_TRACK_URI_LIST']
+  ['player/SET_GET_CURRENT_PLAYBACK_TIMER_ID']: PlayerMutations['SET_GET_CURRENT_PLAYBACK_TIMER_ID']
   ['player/SET_CURRENT_TRACK']: PlayerMutations['SET_CURRENT_TRACK']
   ['player/SET_NEXT_TRACK_LIST']: PlayerMutations['SET_NEXT_TRACK_LIST']
   ['player/SET_PREVIOUS_TRACK_LIST']: PlayerMutations['SET_PREVIOUS_TRACK_LIST']
@@ -75,6 +77,19 @@ const mutations: Mutations<PlayerState, PlayerMutations> = {
 
   SET_RECENTLY_PLAYED(state, recentlyPlayed) {
     state.recentlyPlayed = recentlyPlayed;
+  },
+
+  SET_GET_CURRENT_PLAYBACK_TIMER_ID(state, timer) {
+    const { getCurrentPlaybackTimer } = state;
+    if (typeof getCurrentPlaybackTimer === 'number') {
+      // クライアントサイドで実行
+      window.clearTimeout(getCurrentPlaybackTimer);
+    } else if (getCurrentPlaybackTimer != null) {
+      // サーバーサイドで実行
+      clearTimeout(getCurrentPlaybackTimer);
+    }
+
+    state.getCurrentPlaybackTimer = timer;
   },
 
   SET_CURRENT_TRACK(state, currentTrack) {

--- a/client/store/player/mutations.ts
+++ b/client/store/player/mutations.ts
@@ -10,7 +10,6 @@ export type PlayerMutations = {
   SET_DEVICE_LIST: SpotifyAPI.Device[]
   SET_CUSTOM_CONTEXT_URI: string | undefined
   SET_CUSTOM_TRACK_URI_LIST: string[] | undefined
-  SET_CURRENTLY_PLAYING: SpotifyAPI.Player.CurrentlyPlaying | undefined
   SET_RECENTLY_PLAYED: SpotifyAPI.Player.RecentlyPlayed | undefined
   SET_CURRENT_TRACK: Spotify.Track | undefined
   SET_NEXT_TRACK_LIST: Spotify.Track[]
@@ -34,7 +33,6 @@ export type RootMutations = {
   ['player/SET_DEVICE_LIST']: PlayerMutations['SET_DEVICE_LIST']
   ['player/SET_CUSTOM_CONTEXT_URI']: PlayerMutations['SET_CUSTOM_CONTEXT_URI']
   ['player/SET_CUSTOM_TRACK_URI_LIST']: PlayerMutations['SET_CUSTOM_TRACK_URI_LIST']
-  ['player/SET_CURRENTLY_PLAYING']: PlayerMutations['SET_CURRENTLY_PLAYING']
   ['player/SET_CURRENT_TRACK']: PlayerMutations['SET_CURRENT_TRACK']
   ['player/SET_NEXT_TRACK_LIST']: PlayerMutations['SET_NEXT_TRACK_LIST']
   ['player/SET_PREVIOUS_TRACK_LIST']: PlayerMutations['SET_PREVIOUS_TRACK_LIST']
@@ -73,10 +71,6 @@ const mutations: Mutations<PlayerState, PlayerMutations> = {
 
   SET_CUSTOM_TRACK_URI_LIST(state, trackUriList) {
     state.customTrackUriList = trackUriList;
-  },
-
-  SET_CURRENTLY_PLAYING(state, currentlyPlaying) {
-    state.currentlyPlaying = currentlyPlaying;
   },
 
   SET_RECENTLY_PLAYED(state, recentlyPlayed) {

--- a/client/store/player/mutations.ts
+++ b/client/store/player/mutations.ts
@@ -6,7 +6,8 @@ import type { SpotifyAPI } from '~~/types';
 export type PlayerMutations = {
   SET_PLAYBACK_PLAYER: Spotify.SpotifyPlayer | undefined
   SET_DEVICE_ID: string | undefined
-  SET_ACTIVE_DEVICE_LIST: SpotifyAPI.Device[]
+  SET_ACTIVE_DEVICE_ID: string | undefined
+  SET_DEVICE_LIST: SpotifyAPI.Device[]
   SET_CUSTOM_CONTEXT_URI: string | undefined
   SET_CUSTOM_TRACK_URI_LIST: string[] | undefined
   SET_CURRENTLY_PLAYING: SpotifyAPI.Player.CurrentlyPlaying | undefined
@@ -29,7 +30,8 @@ export type PlayerMutations = {
 export type RootMutations = {
   ['player/SET_PLAYBACK_PLAYER']: PlayerMutations['SET_PLAYBACK_PLAYER']
   ['player/SET_DEVICE_ID']: PlayerMutations['SET_DEVICE_ID']
-  ['player/SET_ACTIVE_DEVICE_LIST']: PlayerMutations['SET_ACTIVE_DEVICE_LIST']
+  ['player/SET_ACTIVE_DEVICE_ID']: PlayerMutations['SET_ACTIVE_DEVICE_ID']
+  ['player/SET_DEVICE_LIST']: PlayerMutations['SET_DEVICE_LIST']
   ['player/SET_CUSTOM_CONTEXT_URI']: PlayerMutations['SET_CUSTOM_CONTEXT_URI']
   ['player/SET_CUSTOM_TRACK_URI_LIST']: PlayerMutations['SET_CUSTOM_TRACK_URI_LIST']
   ['player/SET_CURRENTLY_PLAYING']: PlayerMutations['SET_CURRENTLY_PLAYING']
@@ -57,8 +59,12 @@ const mutations: Mutations<PlayerState, PlayerMutations> = {
     state.deviceId = deviceId;
   },
 
-  SET_ACTIVE_DEVICE_LIST(state, deviceList) {
-    state.activeDeviceList = deviceList;
+  SET_ACTIVE_DEVICE_ID(state, activeDeviceId) {
+    state.activeDeviceId = activeDeviceId;
+  },
+
+  SET_DEVICE_LIST(state, deviceList) {
+    state.deviceList = deviceList;
   },
 
   SET_CUSTOM_CONTEXT_URI(state, contextUri) {

--- a/client/store/player/mutations.ts
+++ b/client/store/player/mutations.ts
@@ -12,6 +12,8 @@ export type PlayerMutations = {
   SET_CUSTOM_TRACK_URI_LIST: string[] | undefined
   SET_RECENTLY_PLAYED: SpotifyAPI.Player.RecentlyPlayed | undefined
   SET_GET_CURRENT_PLAYBACK_TIMER_ID: ReturnType<typeof setTimeout> | number | undefined
+  INCREMENT_RETRY_COUNTS_OF_GET_CURRENT_PLAYBACK: void
+  RESET_RETRY_COUNTS_OF_GET_CURRENT_PLAYBACK: void
   SET_CURRENT_TRACK: Spotify.Track | undefined
   SET_NEXT_TRACK_LIST: Spotify.Track[]
   SET_PREVIOUS_TRACK_LIST: Spotify.Track[]
@@ -35,6 +37,8 @@ export type RootMutations = {
   ['player/SET_CUSTOM_CONTEXT_URI']: PlayerMutations['SET_CUSTOM_CONTEXT_URI']
   ['player/SET_CUSTOM_TRACK_URI_LIST']: PlayerMutations['SET_CUSTOM_TRACK_URI_LIST']
   ['player/SET_GET_CURRENT_PLAYBACK_TIMER_ID']: PlayerMutations['SET_GET_CURRENT_PLAYBACK_TIMER_ID']
+  ['player/INCREMENT_RETRY_COUNTS_OF_GET_CURRENT_PLAYBACK']: PlayerMutations['INCREMENT_RETRY_COUNTS_OF_GET_CURRENT_PLAYBACK']
+  ['player/RESET_RETRY_COUNTS_OF_GET_CURRENT_PLAYBACK']: PlayerMutations['RESET_RETRY_COUNTS_OF_GET_CURRENT_PLAYBACK']
   ['player/SET_CURRENT_TRACK']: PlayerMutations['SET_CURRENT_TRACK']
   ['player/SET_NEXT_TRACK_LIST']: PlayerMutations['SET_NEXT_TRACK_LIST']
   ['player/SET_PREVIOUS_TRACK_LIST']: PlayerMutations['SET_PREVIOUS_TRACK_LIST']
@@ -90,6 +94,13 @@ const mutations: Mutations<PlayerState, PlayerMutations> = {
     }
 
     state.getCurrentPlaybackTimer = timer;
+  },
+  INCREMENT_RETRY_COUNTS_OF_GET_CURRENT_PLAYBACK(state) {
+    state.retryCountsOfGetCurrentPlayback += 1;
+  },
+
+  RESET_RETRY_COUNTS_OF_GET_CURRENT_PLAYBACK(state) {
+    state.retryCountsOfGetCurrentPlayback = 0;
   },
 
   SET_CURRENT_TRACK(state, currentTrack) {

--- a/client/store/player/state.ts
+++ b/client/store/player/state.ts
@@ -6,6 +6,7 @@ export type PlayerState = {
   activeDeviceId: string | undefined
   deviceList: SpotifyAPI.Device[]
   contextUri: string | undefined
+  getCurrentPlaybackTimer: ReturnType<typeof setTimeout> | number | undefined
   trackId: string | undefined
   trackName: string | undefined
   trackUri: string | undefined
@@ -42,6 +43,7 @@ const state = (): PlayerState => ({
   releaseName: undefined,
   releaseUri: undefined,
   artistList: [],
+  getCurrentPlaybackTimer: undefined,
   customContextUri: undefined,
   customTrackUriList: undefined,
   nextTrackList: [],

--- a/client/store/player/state.ts
+++ b/client/store/player/state.ts
@@ -7,6 +7,7 @@ export type PlayerState = {
   deviceList: SpotifyAPI.Device[]
   contextUri: string | undefined
   getCurrentPlaybackTimer: ReturnType<typeof setTimeout> | number | undefined
+  retryCountsOfGetCurrentPlayback: number
   trackId: string | undefined
   trackName: string | undefined
   trackUri: string | undefined
@@ -44,6 +45,7 @@ const state = (): PlayerState => ({
   releaseUri: undefined,
   artistList: [],
   getCurrentPlaybackTimer: undefined,
+  retryCountsOfGetCurrentPlayback: 0,
   customContextUri: undefined,
   customTrackUriList: undefined,
   nextTrackList: [],

--- a/client/store/player/state.ts
+++ b/client/store/player/state.ts
@@ -3,7 +3,8 @@ import type { SpotifyAPI, App } from '~~/types';
 export type PlayerState = {
   playbackPlayer: Spotify.SpotifyPlayer | undefined
   deviceId: string | undefined
-  activeDeviceList: SpotifyAPI.Device[]
+  activeDeviceId: string | undefined
+  deviceList: SpotifyAPI.Device[]
   contextUri: string | undefined
   trackId: string | undefined
   trackName: string | undefined
@@ -32,7 +33,8 @@ export type PlayerState = {
 const state = (): PlayerState => ({
   playbackPlayer: undefined,
   deviceId: undefined,
-  activeDeviceList: [],
+  activeDeviceId: undefined,
+  deviceList: [],
   artWorkList: undefined,
   contextUri: undefined,
   trackId: undefined,

--- a/client/store/player/state.ts
+++ b/client/store/player/state.ts
@@ -17,7 +17,6 @@ export type PlayerState = {
   customTrackUriList: string[] | undefined
   nextTrackList: Spotify.Track[]
   previousTrackList: Spotify.Track[]
-  currentlyPlaying: SpotifyAPI.Player.CurrentlyPlaying | undefined
   recentlyPlayed: SpotifyAPI.Player.RecentlyPlayed | undefined
   isPlaying: boolean
   isSavedTrack: boolean
@@ -47,7 +46,6 @@ const state = (): PlayerState => ({
   customTrackUriList: undefined,
   nextTrackList: [],
   previousTrackList: [],
-  currentlyPlaying: undefined,
   recentlyPlayed: undefined,
   isPlaying: false,
   isSavedTrack: false,

--- a/types/SpotifyAPI.d.ts
+++ b/types/SpotifyAPI.d.ts
@@ -150,23 +150,8 @@ export namespace SpotifyAPI {
     type: 'episode'
     uri: string
   }
-  export type Episode = {
-    available_markets: Country[]
-    copyrights: Copyright[]
-    description: string
-    explicit: boolean
-    episodes: SimpleShow[]
-    external_urls: ExternalUrls
-    href: string
-    id: string
-    images: Image[]
-    is_externally_hosted: boolean
-    languages: string[]
-    media_type: string
-    name: string
-    publisher: string
-    type: string
-    uri: string
+  export type Episode = SimpleEpisode & {
+    show: SimpleShow
   }
 
   // @todo

--- a/types/SpotifyAPI.d.ts
+++ b/types/SpotifyAPI.d.ts
@@ -232,15 +232,20 @@ export namespace SpotifyAPI {
       track: SimpleTrack
     }>
 
-    type CurrentlyPlaying = {
+    type PlayingType = 'track' | 'episode' | 'ad' | 'unknown'
+    type CurrentPlayback<T extends PlayingType = PlayingType> = {
       actions: {
-        disallow?: Disallow
+        disallows: Disallow
       }
       context: Context | null
-      currently_playing_type: 'track' | 'episode' | 'ad' | 'unknown'
+      currently_playing_type: T
       device: Device
       is_playing: boolean
-      item: Track | Episode | null
+      item: T extends 'track'
+        ? Track
+        : T extends 'episode'
+        ? Episode | null
+        : null
       progress_ms: number | null
       repeat_state: RepeatState
       shuffle_state: 'on' | 'off'

--- a/types/SpotifyAPI.d.ts
+++ b/types/SpotifyAPI.d.ts
@@ -233,7 +233,8 @@ export namespace SpotifyAPI {
     }>
 
     type PlayingType = 'track' | 'episode' | 'ad' | 'unknown'
-    type CurrentPlayback<T extends PlayingType = PlayingType> = {
+    // アクティブなデバイスが存在しない場合は空文字が返ってくる
+    type CurrentPlayback<T extends PlayingType = PlayingType> = '' | {
       actions: {
         disallows: Disallow
       }


### PR DESCRIPTION
## About

- close #109 
- related to #163 
- ~~related to #165~~ 
- close #171
- related to #216

### Todo

- [x] `void`を返すプラグインのリクエストは例外を投げうるようにする
- [x] アプリ自体のデバイスIDは `deviceId` に保持し、`activeDeviceId` と区別する
  - [x] `isThisAppPlaying` の変更
- プレイヤー初期化時の処理
  - [x] `getActiveDeviceList`を複数回実行しない
  - [x]  `停止しない`
  - [x] アクティブなデバイスがない場合はこのアプリに `transferPlayback` する
  - [x] ボリュームの取得は `getActiveDeviceList` 内でやる
- [x] `transferPlayback`は必ずリクエストを送信するようにする
  - 他のアプリでデバイスを変更し、実際のデバイスの状態とアプリ内のデバイスの状態の間で不整合が生じた場合はなどでは、 `activeDevice` が同じでも実際は異なる可能性があるため
- [x] `null` -> `undefined`
- 他のデバイスを操作する場合の再生状態の取得
  - ~~`play`/`pause` するときは事前に確認する~~
    - 再生中に `play` をするなどでバグる (`0:00`に戻ったりする)
    - エラー発生した後に確認して不整合を解消
  - [x] 操作した後に再生状態取得
  - [x] 一曲を再生しきって 500 ミリ秒経過後に再生状態取得
  - [x] 最後の再生状態取得から一定時間内 ( 20秒後) に再取得
  - [x] **アプリ内で**デバイス変更後に再取得
  - [x] 再生状態とデバイス一覧で不整合がある場合はデバイス一覧を再取得
    - 他のアプリ内で操作されても検知できないので、苦肉の策
- [x] デバイスのボタン押せないやつ
- [x] エピソードの型 `Episode` 修正
- [x] デバイス見つからないとき再取得 (#109)
- [x]  保存状態の確認