### PR TITLE
#231 ヘッダーの右側にページ内のボタンを表示

### DIFF
--- a/client/components/containers/menu/ArtistMenu.vue
+++ b/client/components/containers/menu/ArtistMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <ContextMenu
     :item-lists="menuItemLists"
-    outlined
+    :outlined="outlined"
     offset-y
     bottom
   />
@@ -33,6 +33,10 @@ export default Vue.extend({
     isFollowing: {
       type: Boolean,
       required: true,
+    },
+    outlined: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/client/components/containers/menu/ArtistMenu.vue
+++ b/client/components/containers/menu/ArtistMenu.vue
@@ -1,9 +1,12 @@
 <template>
   <ContextMenu
     :item-lists="menuItemLists"
+    :size="size"
     :outlined="outlined"
     offset-y
     bottom
+    :left="left"
+    :right="right"
   />
 </template>
 
@@ -34,7 +37,19 @@ export default Vue.extend({
       type: Boolean,
       required: true,
     },
+    size: {
+      type: Number,
+      default: 36,
+    },
     outlined: {
+      type: Boolean,
+      default: false,
+    },
+    left: {
+      type: Boolean,
+      default: false,
+    },
+    right: {
       type: Boolean,
       default: false,
     },
@@ -56,6 +71,8 @@ export default Vue.extend({
           uri: this.artist.uri,
           typeName: 'アーティスト',
           externalUrls: this.artist.externalUrls,
+          left: this.left,
+          right: this.right,
         };
         return {
           component: ShareMenu,

--- a/client/components/containers/menu/PlaylistMenu.vue
+++ b/client/components/containers/menu/PlaylistMenu.vue
@@ -1,9 +1,12 @@
 <template>
   <ContextMenu
     :item-lists="menuItemLists"
+    :size="size"
     :outlined="outlined"
     offset-y
     bottom
+    :left="left"
+    :right="right"
   />
 </template>
 
@@ -37,7 +40,19 @@ export default Vue.extend({
       type: Boolean,
       required: true,
     },
+    size: {
+      type: Number,
+      default: 36,
+    },
     outlined: {
+      type: Boolean,
+      default: false,
+    },
+    left: {
+      type: Boolean,
+      default: false,
+    },
+    right: {
       type: Boolean,
       default: false,
     },
@@ -149,6 +164,8 @@ export default Vue.extend({
           uri: this.playlist.uri,
           typeName: '曲',
           externalUrls: this.playlist.externalUrls,
+          left: this.left,
+          right: this.right,
         };
         return {
           component: ShareMenu,

--- a/client/components/containers/menu/PlaylistMenu.vue
+++ b/client/components/containers/menu/PlaylistMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <ContextMenu
     :item-lists="menuItemLists"
-    outlined
+    :outlined="outlined"
     offset-y
     bottom
   />
@@ -36,6 +36,10 @@ export default Vue.extend({
     isFollowing: {
       type: Boolean,
       required: true,
+    },
+    outlined: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/client/components/containers/menu/ReleaseMenu.vue
+++ b/client/components/containers/menu/ReleaseMenu.vue
@@ -1,9 +1,12 @@
 <template>
   <ContextMenu
     :item-lists="menuItemLists"
+    :size="size"
     :outlined="outlined"
     offset-y
     bottom
+    :left="left"
+    :right="right"
   />
 </template>
 
@@ -32,7 +35,19 @@ export default Vue.extend({
       type: Object as PropType<App.ReleaseInfo>,
       required: true,
     },
+    size: {
+      type: Number,
+      default: 36,
+    },
     outlined: {
+      type: Boolean,
+      default: false,
+    },
+    left: {
+      type: Boolean,
+      default: false,
+    },
+    right: {
       type: Boolean,
       default: false,
     },
@@ -43,7 +58,11 @@ export default Vue.extend({
       const artistPage = () => {
         const { artistList } = this.release;
         if (artistList.length > 1) {
-          const props: ArtistLinkMenuProps = { artistList };
+          const props: ArtistLinkMenuProps = {
+            artistList,
+            left: this.left,
+            right: this.right,
+          };
           return {
             component: ArtistLinkMenu,
             props,
@@ -72,6 +91,8 @@ export default Vue.extend({
           name: this.release.name,
           uriList,
           artistList: this.release.artistList,
+          left: this.left,
+          right: this.right,
         };
 
         return {
@@ -87,6 +108,8 @@ export default Vue.extend({
           typeName: 'アルバム',
           artistList: this.release.artistList,
           externalUrls: this.release.externalUrls,
+          left: this.left,
+          right: this.right,
         };
 
         return {

--- a/client/components/containers/menu/ReleaseMenu.vue
+++ b/client/components/containers/menu/ReleaseMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <ContextMenu
     :item-lists="menuItemLists"
-    outlined
+    :outlined="outlined"
     offset-y
     bottom
   />
@@ -31,6 +31,10 @@ export default Vue.extend({
     release: {
       type: Object as PropType<App.ReleaseInfo>,
       required: true,
+    },
+    outlined: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/client/components/containers/menu/TrackMenu.vue
+++ b/client/components/containers/menu/TrackMenu.vue
@@ -1,6 +1,7 @@
 <template>
   <ContextMenu
     :item-lists="menuItemLists"
+    :outlined="outlined"
     offset-x
     left
   />
@@ -34,6 +35,10 @@ export default Vue.extend({
     playlistId: {
       type: String as PropType<string | undefined>,
       default: undefined,
+    },
+    outlined: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/client/components/globals/Footer.vue
+++ b/client/components/globals/Footer.vue
@@ -34,7 +34,7 @@
           <FavoriteButton
             v-if="hasTrack"
             :is-favorited="isSavedTrack"
-            :size="20"
+            :size="36"
             @on-clicked="onFavoriteButtonClicked"
           />
         </div>

--- a/client/components/globals/Header.vue
+++ b/client/components/globals/Header.vue
@@ -39,13 +39,15 @@
       </div>
 
       <div :class="$style.Header__right">
-        <transition name="fade">
-          <portal-target
-            v-show="$header.isAdditionalContentShown"
-            :name="$header.PORTAL_NAME"
-            :class="$style.Header__additional"
-          />
-        </transition>
+        <template v-if="$header.hasAdditionalContent">
+          <transition name="fade">
+            <portal-target
+              v-show="$header.isAdditionalContentShown"
+              :name="$header.PORTAL_NAME"
+              :class="$style.Header__additional"
+            />
+          </transition>
+        </template>
       </div>
     </div>
   </v-app-bar>

--- a/client/components/globals/Header.vue
+++ b/client/components/globals/Header.vue
@@ -3,8 +3,6 @@
     app
     :elevation="elevation"
     :height="HEADER_HEIGHT"
-    :extended="$header.isOn && $header.isExtended"
-    :extension-height="$header.extensionHeight"
     :style="styles"
     :class="$style.Header"
   >
@@ -40,20 +38,16 @@
         </div>
       </div>
 
-      <div :class="$style.Header__right" />
-    </div>
-
-    <template #extension>
-      <template v-if="$header.isOn">
+      <div :class="$style.Header__right">
         <transition name="fade">
           <portal-target
-            v-show="$header.isExtended"
+            v-show="$header.isAdditionalContentShown"
             :name="$header.PORTAL_NAME"
-            :class="$style.Header__extension"
+            :class="$style.Header__additional"
           />
         </transition>
-      </template>
-    </template>
+      </div>
+    </div>
   </v-app-bar>
 </template>
 
@@ -110,16 +104,11 @@ export default Vue.extend({
   z-index: z-index-of(header) !important;
   backdrop-filter: blur(16px);
 
-  &__main,
-  &__extension > *:first-child {
+  &__container {
     display: flex;
     justify-content: space-between;
     width: 100%;
     padding: 0 8px;
-  }
-
-  &__extension {
-    width: 100%;
   }
 
   &__left,

--- a/client/components/parts/button/CircleButton.vue
+++ b/client/components/parts/button/CircleButton.vue
@@ -1,11 +1,13 @@
 <template>
   <v-btn
     icon
-    v-bind="buttonProps"
+    :width="size"
+    :height="size"
+    :outlined="outlined"
     :disabled="disabled"
     @click="onClicked"
   >
-    <v-icon :size="iconSize">
+    <v-icon :size="iconSize || ((size * 0.8) / Math.SQRT2)">
       <slot />
     </v-icon>
   </v-btn>
@@ -13,12 +15,6 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-
-type ButtonProps = {
-  [k in 'x-large' | 'large' | 'small' | 'x-small']?: true
-} & {
-  outlined: boolean
-}
 
 const ON_CLICKED = 'on-clicked';
 
@@ -29,7 +25,11 @@ export type On = {
 export default Vue.extend({
   props: {
     size: {
-      type: [Number, String] as PropType<number | 'x-large' | 'large' | 'small' | 'x-small'>,
+      type: Number,
+      default: 36,
+    },
+    iconSize: {
+      type: Number as PropType<number | undefined>,
       default: undefined,
     },
     outlined: {
@@ -39,34 +39,6 @@ export default Vue.extend({
     disabled: {
       type: Boolean,
       default: false,
-    },
-  },
-
-  computed: {
-    buttonProps(): ButtonProps {
-      return typeof this.size === 'number'
-        ? {
-          outlined: false,
-        }
-        : {
-          [this.size]: true,
-          outlined: this.outlined,
-        };
-    },
-    iconSize(): number {
-      // 数値で指定するときは outlined 無効の時のみ有効
-      if (!this.outlined && typeof this.size === 'number') return this.size;
-
-      switch (this.size) {
-        case 'x-small':
-          return 12;
-        case 'small':
-          return 16;
-        case 'large' || 'x-large':
-          return 24;
-        default:
-          return 20;
-      }
     },
   },
 

--- a/client/components/parts/button/FavoriteButton.vue
+++ b/client/components/parts/button/FavoriteButton.vue
@@ -1,7 +1,9 @@
 <template>
   <v-btn
     icon
-    v-bind="buttonProps"
+    :width="size"
+    :height="size"
+    :outlined="outlined"
     :disabled="disabled"
     :title="title"
     @click="onClicked"
@@ -13,13 +15,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
-
-type ButtonProps = {
-  [k in 'x-large' | 'large' | 'small' | 'x-small']?: true
-} & {
-  outlined: boolean
-}
+import Vue from 'vue';
 
 export type FavoriteIcon = 'mdi-heart' | 'mdi-heart-outline';
 
@@ -36,8 +32,8 @@ export default Vue.extend({
       required: true,
     },
     size: {
-      type: [Number, String] as PropType<number | 'x-large' | 'large' | 'small' | 'x-small'>,
-      default: undefined,
+      type: Number,
+      default: 36,
     },
     outlined: {
       type: Boolean,
@@ -60,30 +56,8 @@ export default Vue.extend({
         ? '保存しない'
         : '保存する';
     },
-    buttonProps(): ButtonProps {
-      return typeof this.size === 'number'
-        ? {
-          outlined: false,
-        }
-        : {
-          [this.size]: true,
-          outlined: this.outlined,
-        };
-    },
     iconSize(): number {
-      // 数値で指定するときは outlined 無効の時のみ有効
-      if (!this.outlined && typeof this.size === 'number') return this.size;
-
-      switch (this.size) {
-        case 'x-small':
-          return 12;
-        case 'small':
-          return 16;
-        case 'large' || 'x-large':
-          return 24;
-        default:
-          return 20;
-      }
+      return (this.size * 0.8) / Math.SQRT2;
     },
   },
 

--- a/client/components/parts/button/FollowButton.vue
+++ b/client/components/parts/button/FollowButton.vue
@@ -3,7 +3,8 @@
     <v-btn
       rounded
       :outlined="isFollowing"
-      :width="180"
+      :height="height"
+      :width="160"
       @click="onClicked"
     >
       <v-icon
@@ -35,6 +36,10 @@ export default Vue.extend({
     isFollowing: {
       type: Boolean,
       required: true,
+    },
+    height: {
+      type: Number,
+      default: 36,
     },
   },
 

--- a/client/components/parts/menu/ContextMenu.vue
+++ b/client/components/parts/menu/ContextMenu.vue
@@ -12,7 +12,8 @@
     <template #activator="{ on }">
       <v-btn
         icon
-        size="small"
+        :height="36"
+        :width="36"
         :outlined="outlined"
         :disabled="disabled"
         title="メニュー"

--- a/client/components/parts/menu/ContextMenu.vue
+++ b/client/components/parts/menu/ContextMenu.vue
@@ -12,8 +12,8 @@
     <template #activator="{ on }">
       <v-btn
         icon
-        :height="36"
-        :width="36"
+        :height="size"
+        :width="size"
         :outlined="outlined"
         :disabled="disabled"
         title="メニュー"
@@ -101,6 +101,10 @@ type Data = {
 
 export default Vue.extend({
   props: {
+    size: {
+      type: Number,
+      default: 36,
+    },
     outlined: {
       type: Boolean,
       default: false,

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -114,7 +114,7 @@ export default Vue.extend({
         // intersectionRatio は 0 ~ 1
         this.elevation = Math.ceil(8 * (1 - entry.intersectionRatio));
         // spacer が完全に隠れたらヘッダーを表示
-        this.$header.change(!entry.isIntersecting);
+        this.$header.changeAdditionalContent(!entry.isIntersecting);
       });
     }, {
       threshold: [0, 0.2, 0.4, 0.6, 0.8, 1],

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -113,8 +113,6 @@ export default Vue.extend({
       entries.forEach((entry) => {
         // intersectionRatio は 0 ~ 1
         this.elevation = Math.ceil(8 * (1 - entry.intersectionRatio));
-        // spacer が完全に隠れたらヘッダーを表示
-        this.$header.changeAdditionalContent(!entry.isIntersecting);
       });
     }, {
       threshold: [0, 0.2, 0.4, 0.6, 0.8, 1],

--- a/client/observable/header.ts
+++ b/client/observable/header.ts
@@ -3,59 +3,53 @@ import Vue from 'vue';
 const PORTAL_NAME = 'CONTENT_HEADER';
 
 type HeaderState = {
-  isOn: boolean
-  isExtended: boolean
+  hasAdditionalContentShown: boolean
+  isAdditionalContentShown: boolean
   isIntersecting: boolean
 }
 
 export type Header = {
-  readonly isExtended: boolean
-  readonly isOn: boolean
-  readonly extensionHeight: number
+  readonly isAdditionalContentShown: boolean
+  readonly hasAdditionalContentShown: boolean
   readonly PORTAL_NAME: typeof PORTAL_NAME
-  change: (isShown: boolean) => void
-  on: () => void
+  changeAdditionalContent: (isShown: boolean) => void
+  enableAdditionalContent: () => void
   reset: () => void
 }
 
 const state = Vue.observable<HeaderState>({
-  isOn: false,
-  isExtended: false,
+  hasAdditionalContentShown: false,
+  isAdditionalContentShown: false,
   // spacer の isIntersecting
   isIntersecting: true,
 });
 
 export const $header: Header = {
-  get isExtended(): boolean {
-    return state.isExtended;
+  get isAdditionalContentShown(): boolean {
+    return state.isAdditionalContentShown;
   },
-  get isOn(): boolean {
-    return state.isOn;
-  },
-  get extensionHeight(): number {
-    return state.isExtended && state.isOn
-      ? 44
-      : 0;
+  get hasAdditionalContentShown(): boolean {
+    return state.hasAdditionalContentShown;
   },
   get PORTAL_NAME(): typeof PORTAL_NAME {
     return PORTAL_NAME;
   },
 
-  change(isShown: boolean) {
-    state.isExtended = isShown;
+  changeAdditionalContent(isShown: boolean) {
+    state.isAdditionalContentShown = isShown;
     state.isIntersecting = !isShown;
   },
-  on() {
-    state.isOn = true;
+  enableAdditionalContent() {
+    state.hasAdditionalContentShown = true;
     // @todo 戻る/進むボタンでちらつかないように遅らせる
     setTimeout(() => {
       if (!state.isIntersecting) {
-        state.isExtended = true;
+        state.isAdditionalContentShown = true;
       }
     }, 1000);
   },
   reset() {
-    state.isExtended = false;
-    state.isOn = false;
+    state.isAdditionalContentShown = false;
+    state.hasAdditionalContentShown = false;
   },
 };

--- a/client/pages/artists/_artistId.vue
+++ b/client/pages/artists/_artistId.vue
@@ -62,6 +62,7 @@
             <ArtistMenu
               :artist="artistInfo"
               :is-following="isFollowing"
+              outlined
               @on-follow-menu-clicked="toggleFolloingState"
             />
           </div>

--- a/client/pages/artists/_artistId.vue
+++ b/client/pages/artists/_artistId.vue
@@ -215,7 +215,6 @@ export type AsyncData = {
 
 export type Data = {
   mutationUnsubscribe: (() => void) | undefined
-  intersectionObserver: IntersectionObserver | undefined,
   HEADER_REF: string
   ABBREVIATED_TOP_TRACK_LENGTH: typeof ABBREVIATED_TOP_TRACK_LENGTH
 }
@@ -276,7 +275,6 @@ export default class ArtistIdPage extends Vue implements AsyncData, Data {
   ABBREVIATED_RELEASE_LENGTH = ABBREVIATED_RELEASE_LENGTH;
 
   mutationUnsubscribe: (() => void) | undefined = undefined;
-  intersectionObserver: IntersectionObserver | undefined = undefined;
   HEADER_REF = HEADER_REF;
   ABBREVIATED_TOP_TRACK_LENGTH: typeof ABBREVIATED_TOP_TRACK_LENGTH = ABBREVIATED_TOP_TRACK_LENGTH;
 
@@ -296,19 +294,8 @@ export default class ArtistIdPage extends Vue implements AsyncData, Data {
   mounted() {
     // ボタンが見えなくなったらヘッダーに表示
     if (this.artistInfo != null) {
-      this.$header.enableAdditionalContent();
-
-      const ref = this.$refs[this.HEADER_REF] as HTMLDivElement;
-      if (ref == null) return;
-
-      this.intersectionObserver = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          this.$header.changeAdditionalContent(!entry.isIntersecting);
-        });
-      }, {
-        rootMargin: '-52px 0px',
-      });
-      this.intersectionObserver.observe(ref);
+      const ref = this.$refs[HEADER_REF] as HTMLDivElement;
+      this.$header.observe(ref);
     }
 
     this.$dispatch('setDefaultDominantBackgroundColor');
@@ -352,16 +339,11 @@ export default class ArtistIdPage extends Vue implements AsyncData, Data {
   }
 
   beforeDestroy() {
-    this.$header.reset();
+    this.$header.disconnectObserver();
 
     if (this.mutationUnsubscribe != null) {
       this.mutationUnsubscribe();
       this.mutationUnsubscribe = undefined;
-    }
-
-    if (this.intersectionObserver != null) {
-      this.intersectionObserver.disconnect();
-      this.intersectionObserver = undefined;
     }
   }
 
@@ -470,6 +452,15 @@ export default class ArtistIdPage extends Vue implements AsyncData, Data {
 </script>
 
 <style lang="scss" module>
+.AdditionalHeaderContent {
+  display: flex;
+  flex-wrap: nowrap;
+
+  & > *:not(:last-child) {
+    margin-right: 0.5vw;
+  }
+}
+
 .ArtistIdPage {
   padding: 16px 6% 48px;
 
@@ -521,12 +512,6 @@ export default class ArtistIdPage extends Vue implements AsyncData, Data {
     &__buttonWrapper {
       display: flex;
       justify-content: center;
-    }
-  }
-
-  .AdditionalHeaderContent {
-    & > *:not(:last-child) {
-      margin-right: 1%;
     }
   }
 

--- a/client/pages/library/releases.vue
+++ b/client/pages/library/releases.vue
@@ -1,11 +1,5 @@
 <template>
   <div :class="$style.LibraryReleasesPage">
-    <portal :to="$header.PORTAL_NAME">
-      <h2 :class="$style.ExtendedHeader__title">
-        {{ title }}
-      </h2>
-    </portal>
-
     <h1>
       {{ title }}
     </h1>

--- a/client/pages/library/tracks.vue
+++ b/client/pages/library/tracks.vue
@@ -1,17 +1,11 @@
 <template>
   <div :class="$style.LibraryTracksPage">
     <portal :to="$header.PORTAL_NAME">
-      <div :class="$style.ExtendedHeader">
-        <h2 :class="$style.ExtendedHeader__title">
-          {{ title }}
-        </h2>
-
-        <ContextMediaButton
-          :height="32"
-          :is-playing="isPlaylistSet && isPlaying"
-          @on-clicked="onContextMediaButtonClicked"
-        />
-      </div>
+      <ContextMediaButton
+        :height="32"
+        :is-playing="isPlaylistSet && isPlaying"
+        @on-clicked="onContextMediaButtonClicked"
+      />
     </portal>
 
     <h1>
@@ -103,7 +97,7 @@ export default class LibraryTracksPage extends Vue implements Data {
   }
 
   mounted() {
-    this.$header.on();
+    this.$header.enableAdditionalContent();
 
     this.$dispatch('setDefaultDominantBackgroundColor');
 

--- a/client/pages/library/tracks.vue
+++ b/client/pages/library/tracks.vue
@@ -13,6 +13,7 @@
     </h1>
 
     <ContextMediaButton
+      :ref="MEDIA_BUTTON_REF"
       :is-playing="isPlaylistSet && isPlaying"
       @on-clicked="onContextMediaButtonClicked"
     />
@@ -47,8 +48,10 @@ interface Data {
   uri: string
   observer: IntersectionObserver | undefined
   mutationUnsubscribe: (() => void) | undefined
+  MEDIA_BUTTON_REF: string
 }
 
+const MEDIA_BUTTON_REF = 'mediaButtonRef';
 const LIMIT_OF_TRACKS = 30 as const;
 
 @Component({
@@ -76,6 +79,7 @@ export default class LibraryTracksPage extends Vue implements Data {
   uri = generateCollectionContextUri(this.$getters()['auth/userId']!);
   observer: IntersectionObserver | undefined = undefined;
   mutationUnsubscribe: (() => void) | undefined = undefined;
+  MEDIA_BUTTON_REF = MEDIA_BUTTON_REF;
 
   head() {
     return {
@@ -97,7 +101,8 @@ export default class LibraryTracksPage extends Vue implements Data {
   }
 
   mounted() {
-    this.$header.enableAdditionalContent();
+    const element = this.$refs[MEDIA_BUTTON_REF] as Vue;
+    this.$header.observe(element.$el);
 
     this.$dispatch('setDefaultDominantBackgroundColor');
 
@@ -114,7 +119,7 @@ export default class LibraryTracksPage extends Vue implements Data {
   }
 
   beforeDestroy() {
-    this.$header.reset();
+    this.$header.disconnectObserver();
 
     if (this.mutationUnsubscribe != null) {
       this.mutationUnsubscribe();

--- a/client/pages/playlists/_playlistId.vue
+++ b/client/pages/playlists/_playlistId.vue
@@ -67,6 +67,7 @@
             <PlaylistMenu
               :playlist="playlistInfo"
               :is-following="isFollowing"
+              outlined
               @on-edit-menu-clicked="toggleEditPlaylistModal"
               @on-follow-menu-clicked="toggleFollowingState"
             />

--- a/client/pages/playlists/_playlistId.vue
+++ b/client/pages/playlists/_playlistId.vue
@@ -6,7 +6,6 @@
     <portal :to="$header.PORTAL_NAME">
       <div
         v-if="playlistInfo != null"
-        :ref="HEADER_REF"
         :class="$style.AdditionalHeaderContent"
       >
         <ContextMediaButton
@@ -47,7 +46,11 @@
       </div>
     </portal>
 
-    <div :class="$style.PlaylistIdPage__header">
+    <div
+      v-if="playlistInfo != null"
+      :ref="HEADER_REF"
+      :class="$style.PlaylistIdPage__header"
+    >
       <ReleaseArtwork
         :src="playlistInfo.artworkSrc"
         :alt="playlistInfo.name"
@@ -245,7 +248,6 @@ export default class PlaylistIdPage extends Vue implements AsyncData, Data {
 
   editPlaylistModal = false;
   mutationUnsubscribe: (() => void) | undefined = undefined;
-  intersectionObserver: IntersectionObserver | undefined = undefined;
   HEADER_REF = HEADER_REF;
 
   head() {
@@ -257,19 +259,8 @@ export default class PlaylistIdPage extends Vue implements AsyncData, Data {
   mounted() {
     // ボタンが見えなくなったらヘッダーに表示
     if (this.playlistInfo != null) {
-      this.$header.enableAdditionalContent();
-
-      const ref = this.$refs[this.HEADER_REF] as HTMLDivElement;
-      if (ref == null) return;
-
-      this.intersectionObserver = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          this.$header.changeAdditionalContent(!entry.isIntersecting);
-        });
-      }, {
-        rootMargin: '-52px 0px',
-      });
-      this.intersectionObserver.observe(ref);
+      const ref = this.$refs[HEADER_REF] as HTMLDivElement;
+      this.$header.observe(ref);
     }
 
     if (this.playlistInfo?.artworkSrc != null) {
@@ -407,7 +398,7 @@ export default class PlaylistIdPage extends Vue implements AsyncData, Data {
   }
 
   beforeDestroy() {
-    this.$header.reset();
+    this.$header.disconnectObserver();
 
     if (this.mutationUnsubscribe != null) {
       this.mutationUnsubscribe();
@@ -540,6 +531,15 @@ export default class PlaylistIdPage extends Vue implements AsyncData, Data {
 </script>
 
 <style lang="scss" module>
+.AdditionalHeaderContent {
+  display: flex;
+  flex-wrap: nowrap;
+
+  & > *:not(:last-child) {
+    margin-right: 0.5vw;
+  }
+}
+
 .PlaylistIdPage {
   padding: 16px 6% 48px;
 
@@ -589,12 +589,6 @@ export default class PlaylistIdPage extends Vue implements AsyncData, Data {
 
   &__table {
     margin-bottom: 32px;
-  }
-
-  .AdditionalHeaderContent {
-    & > *:not(:last-child) {
-      margin-right: 1%;
-    }
   }
 }
 </style>

--- a/client/pages/playlists/_playlistId.vue
+++ b/client/pages/playlists/_playlistId.vue
@@ -49,6 +49,7 @@
 
             <template v-if="playlistInfo.isOwnPlaylist">
               <CircleButton
+                :size="36"
                 outlined
                 title="編集する"
                 @on-clicked="editPlaylistModal = true"

--- a/client/pages/releases/_releaseId.vue
+++ b/client/pages/releases/_releaseId.vue
@@ -6,7 +6,6 @@
     <portal :to="$header.PORTAL_NAME">
       <div
         v-if="releaseInfo != null"
-        :ref="HEADER_REF"
         :class="$style.AdditionalHeaderContent"
       >
         <ContextMediaButton
@@ -32,7 +31,11 @@
       </div>
     </portal>
 
-    <div :class="$style.ReleaseIdPage__header">
+    <div
+      v-if="releaseInfo != null"
+      :ref="HEADER_REF"
+      :class="$style.ReleaseIdPage__header"
+    >
       <ReleaseArtwork
         :src="releaseInfo.artworkSrc"
         :alt="releaseInfo.name"
@@ -174,7 +177,6 @@ interface AsyncData {
 
 interface Data {
   mutationUnsubscribe: (() => void) | undefined
-  intersectionObserver: IntersectionObserver | undefined
   HEADER_REF: string
 }
 
@@ -218,7 +220,6 @@ export default class ReleaseIdPage extends Vue implements AsyncData, Data {
   CARD_WIDTH = CARD_WIDTH;
 
   mutationUnsubscribe: (() => void) | undefined = undefined;
-  intersectionObserver: IntersectionObserver | undefined;
   HEADER_REF = HEADER_REF;
 
   head() {
@@ -230,19 +231,8 @@ export default class ReleaseIdPage extends Vue implements AsyncData, Data {
   mounted() {
     // ボタンが見えなくなったらヘッダーに表示
     if (this.releaseInfo != null) {
-      this.$header.enableAdditionalContent();
-
-      const ref = this.$refs[this.HEADER_REF] as HTMLDivElement;
-      if (ref == null) return;
-
-      this.intersectionObserver = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          this.$header.changeAdditionalContent(!entry.isIntersecting);
-        });
-      }, {
-        rootMargin: '-52px 0px',
-      });
-      this.intersectionObserver.observe(ref);
+      const ref = this.$refs[HEADER_REF] as HTMLDivElement;
+      this.$header.observe(ref);
     }
 
     if (this.releaseInfo?.artworkSrc != null) {
@@ -293,7 +283,7 @@ export default class ReleaseIdPage extends Vue implements AsyncData, Data {
   }
 
   beforeDestroy() {
-    this.$header.reset();
+    this.$header.disconnectObserver();
 
     if (this.mutationUnsubscribe != null) {
       this.mutationUnsubscribe();
@@ -400,6 +390,15 @@ export default class ReleaseIdPage extends Vue implements AsyncData, Data {
 </script>
 
 <style lang="scss" module>
+.AdditionalHeaderContent {
+  display: flex;
+  flex-wrap: nowrap;
+
+  & > *:not(:last-child) {
+    margin-right: 0.5vw;
+  }
+}
+
 .ReleaseIdPage {
   padding: 16px 6% 48px;
 
@@ -459,12 +458,6 @@ export default class ReleaseIdPage extends Vue implements AsyncData, Data {
 
   &__section {
     margin: 40px -32px 0;
-  }
-
-  .AdditionalHeaderContent {
-    & > *:not(:last-child) {
-      margin-right: 1%;
-    }
   }
 }
 </style>

--- a/client/pages/releases/_releaseId.vue
+++ b/client/pages/releases/_releaseId.vue
@@ -46,6 +46,7 @@
 
             <ReleaseMenu
               :release="releaseInfo"
+              outlined
               @on-favorite-menu-clicked="toggleSavedState"
             />
           </div>


### PR DESCRIPTION
## About

- close #231
- スクロールした際、ヘッダーの右側にページ内のボタンを表示するようにした
  - [x] `/library/tracks`
  - [x] `/artists/{artistId}`
  - [x] `/releases/{releaseId}'`
  - [x] `/playlists/{playlistId}`
- Menu コンポーネントに `left`, `right`, `size` props を追加
- `FavoriteButton` の `size`
- `ContextMediaButton` と `FollowButton` の `height`
