### PR TITLE
再生リストから再生するとき

### DIFF
--- a/client/components/containers/player/TrackQueueMenu.vue
+++ b/client/components/containers/player/TrackQueueMenu.vue
@@ -106,28 +106,39 @@ export default Vue.extend({
   },
 
   methods: {
-    onItemClicked(uri: OnItem['on-item-clicked']) {
-      const { contextUri, customTrackUriList } = this.$state().player;
+    async onItemClicked({ index }: OnItem['on-item-clicked']) {
+      const isNext = index > 0;
+      const counts = Math.abs(index);
+
+      // @todo #174 次に再生に追加した曲が再生できないのに対処するため
+      for (let i = 0; i < counts; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await this.$dispatch(isNext
+          ? 'player/next'
+          : 'player/previous');
+      }
+
+      // const { contextUri, customTrackUriList } = this.$state().player;
 
       // album と playlist は contextUri + offset で操作できる
-      if (contextUri != null && /album|playlist/.test(contextUri)) {
-        // @todo #54 プレイリスト再生の際 position を uri で指定すると、403 が返る場合があるので index で指定
-        this.$dispatch('player/play', {
-          contextUri,
-          offset: customTrackUriList != null && contextUri.includes('playlist')
-            ? { position: customTrackUriList?.findIndex((trackUri) => trackUri === uri) }
-            : { uri },
-        });
-      } else {
-        // playback-sdk から提供される contextUri が不適当かどうかで場合分け
-        const trackUriList = contextUri == null && customTrackUriList != null
-          ? customTrackUriList
-          : this.trackQueue.map((track) => track.uri);
-        this.$dispatch('player/play', {
-          trackUriList,
-          offset: { uri },
-        });
-      }
+      // if (contextUri != null && /album|playlist/.test(contextUri)) {
+      //   // @todo #54 プレイリスト再生の際 position を uri で指定すると、403 が返る場合があるので index で指定
+      //   this.$dispatch('player/play', {
+      //     contextUri,
+      //     offset: customTrackUriList != null && contextUri.includes('playlist')
+      //       ? { position: customTrackUriList?.findIndex((trackUri) => trackUri === uri) }
+      //       : { uri },
+      //   });
+      // } else {
+      //   // playback-sdk から提供される contextUri が不適当かどうかで場合分け
+      //   const trackUriList = contextUri == null && customTrackUriList != null
+      //     ? customTrackUriList
+      //     : this.trackQueue.map((track) => track.uri);
+      //   this.$dispatch('player/play', {
+      //     trackUriList,
+      //     offset: { uri },
+      //   });
+      // }
     },
     toggleMenu() {
       this.isShown = !this.isShown;

--- a/client/components/parts/list/TrackQueueMenuItem.vue
+++ b/client/components/parts/list/TrackQueueMenuItem.vue
@@ -88,7 +88,10 @@ const ON_ITEM_CLICKED = 'on-item-clicked';
 const ON_LINK_CLICKED = 'on-link-clicked';
 
 export type On = {
-  [ON_ITEM_CLICKED]: string
+  [ON_ITEM_CLICKED]: {
+    index: number
+    uri: string
+  }
   [ON_LINK_CLICKED]: void
 }
 
@@ -110,6 +113,10 @@ export default Vue.extend({
     },
     id: {
       type: String,
+      required: true,
+    },
+    index: {
+      type: Number,
       required: true,
     },
     name: {
@@ -150,7 +157,10 @@ export default Vue.extend({
 
   methods: {
     onItemClicked() {
-      this.$emit(ON_ITEM_CLICKED, this.uri);
+      this.$emit(ON_ITEM_CLICKED, {
+        index: this.index,
+        uri: this.uri,
+      });
     },
     onLinkClicked() {
       this.$emit(ON_LINK_CLICKED);

--- a/client/scripts/converter/convertTrackForQueue.ts
+++ b/client/scripts/converter/convertTrackForQueue.ts
@@ -6,16 +6,18 @@ type ExtendedTrack = Spotify.Track & {
   duration_ms?: number
 }
 
-export const convertTrackForQueue = ({ isSet, isPlaying }: {
+export const convertTrackForQueue = ({ isSet, isPlaying, offset = 0 }: {
   isSet: boolean
   isPlaying: boolean
-}) => (track: ExtendedTrack | SpotifyAPI.Track): App.TrackQueueInfo => {
+  offset?: number
+}) => (track: ExtendedTrack | SpotifyAPI.Track, i: number): App.TrackQueueInfo => {
   // Array#map 関数が呼べるように型を定義する
   const { artists }: { artists: (Spotify.Artist | SpotifyAPI.SimpleArtist)[]} = track;
 
   const info = {
     isSet,
     isPlaying,
+    index: i + offset,
     id: track.id ?? undefined,
     name: track.name,
     uri: track.uri,

--- a/client/scripts/converter/convertTrackForQueue.ts
+++ b/client/scripts/converter/convertTrackForQueue.ts
@@ -6,10 +6,10 @@ type ExtendedTrack = Spotify.Track & {
   duration_ms?: number
 }
 
-export const convertTrackForQueue = (
-  isSet: boolean,
-  isPlaying: boolean,
-) => (track: ExtendedTrack | SpotifyAPI.Track): App.TrackQueueInfo => {
+export const convertTrackForQueue = ({ isSet, isPlaying }: {
+  isSet: boolean
+  isPlaying: boolean
+}) => (track: ExtendedTrack | SpotifyAPI.Track): App.TrackQueueInfo => {
   // Array#map 関数が呼べるように型を定義する
   const { artists }: { artists: (Spotify.Artist | SpotifyAPI.SimpleArtist)[]} = track;
 

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -42,8 +42,8 @@ export type PlayerActions = {
     positionMs: number
     currentPositionMs?: number
   }) => Promise<void>
-  next: () => void
-  previous: () => void
+  next: () => Promise<void>
+  previous: () => Promise<void>
   shuffle: () => Promise<void>
   repeat: () => Promise<void>
   volume: ({ volumePercent }: { volumePercent: ZeroToHundred }) => Promise<void>

--- a/client/store/player/getters.ts
+++ b/client/store/player/getters.ts
@@ -73,10 +73,20 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
       artworkList: state.artworkList ?? [],
       durationMs: state.durationMs,
     };
+    // 前後2曲まで含める
     const previousTrackList = state.previousTrackList
-      .map(convertTrackForQueue(false, false));
+      .slice(0, 2)
+      .map(convertTrackForQueue({
+        isSet: false,
+        isPlaying: false,
+      }));
+
     const nextTrackList = state.nextTrackList
-      .map(convertTrackForQueue(false, false));
+      .slice(0, 2)
+      .map(convertTrackForQueue({
+        isSet: false,
+        isPlaying: false,
+      }));
 
     return [
       ...previousTrackList,

--- a/client/store/player/getters.ts
+++ b/client/store/player/getters.ts
@@ -64,6 +64,7 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
     const currentTrack = {
       isSet: true,
       isPlaying: state.isPlaying,
+      index: 0,
       id: state.trackId,
       name: state.trackName!,
       uri: state.trackUri!,
@@ -73,12 +74,15 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
       artworkList: state.artworkList ?? [],
       durationMs: state.durationMs,
     };
+
+    const prevLength = Math.min(state.previousTrackList.length, 2);
     // 前後2曲まで含める
     const previousTrackList = state.previousTrackList
       .slice(0, 2)
       .map(convertTrackForQueue({
         isSet: false,
         isPlaying: false,
+        offset: -1 * prevLength,
       }));
 
     const nextTrackList = state.nextTrackList
@@ -86,6 +90,7 @@ const playerGetters: Getters<PlayerState, PlayerGetters> = {
       .map(convertTrackForQueue({
         isSet: false,
         isPlaying: false,
+        offset: 1,
       }));
 
     return [

--- a/types/App.d.ts
+++ b/types/App.d.ts
@@ -39,6 +39,7 @@ export namespace App {
   export type TrackQueueInfo = {
     isSet: boolean
     isPlaying: boolean
+    index: number
     id: string | undefined
     name: string
     uri: string


### PR DESCRIPTION
## About

- close #174
- close #54
- 再生リストの一覧は前後2曲まで表示する
- 「次に再生」に追加した曲を再生リスト一覧から再生しようとするとエラーが発生するのに対処
  - `next` / `previous` を現在の曲から `offset` 回分だけリクエストを送っている
  - 最大でも2回なのでとりあえずよしとする
