### PR TITLE
追加したユーザーのカラム

### DIFF
--- a/client/components/containers/table/PlaylistTrackTable.vue
+++ b/client/components/containers/table/PlaylistTrackTable.vue
@@ -128,13 +128,11 @@ export default Vue.extend({
       text: '',
       value: 'addedBy',
       width: 96,
-      align: 'center' as const,
     };
     const addedAtColumn = {
       text: '',
       value: 'addedAt',
       width: 80,
-      align: 'center' as const,
     };
     const durationColumn = {
       text: '',

--- a/client/components/containers/table/PlaylistTrackTable.vue
+++ b/client/components/containers/table/PlaylistTrackTable.vue
@@ -33,6 +33,7 @@
           :item="item"
           :playlist-id="playlistId"
           :added-at="addedAt"
+          :collaborative="collaborative"
           :is-active="item.id === activeRowId"
           :is-track-set="isTrackSet(item.id)"
           :is-playing-track="isPlayingTrack(item.id)"
@@ -90,6 +91,10 @@ export default Vue.extend({
       type: Boolean,
       default: false,
     },
+    collaborative: {
+      type: Boolean,
+      default: false,
+    },
     addedAt: {
       type: Boolean,
       default: true,
@@ -109,10 +114,16 @@ export default Vue.extend({
       text: 'タイトル',
       value: 'name',
     };
+    const addedByColumn = {
+      text: 'ユーザー',
+      value: 'addedBy',
+      width: 96,
+      align: 'center' as const,
+    };
     const addedAtColumn = {
       text: '',
       value: 'addedAt',
-      width: 72,
+      width: 80,
       align: 'center' as const,
     };
     const durationColumn = {
@@ -130,21 +141,15 @@ export default Vue.extend({
       filterable: false,
     };
 
-    // addedAt が有効かどうか
-    const headers = this.addedAt
-      ? [
-        isSavedColumn,
-        titleColumn,
-        addedAtColumn,
-        durationColumn,
-        menuColumn,
-      ]
-      : [
-        isSavedColumn,
-        titleColumn,
-        durationColumn,
-        menuColumn,
-      ];
+    // @as addedAt, addedBy が有効かどうかで分け、undefined を除く
+    const headers = [
+      isSavedColumn,
+      titleColumn,
+      this.collaborative ? addedByColumn : undefined,
+      this.addedAt ? addedAtColumn : undefined,
+      durationColumn,
+      menuColumn,
+    ].filter((header) => header != null) as DataTableHeader[];
 
     return {
       headers,

--- a/client/components/containers/table/PlaylistTrackTable.vue
+++ b/client/components/containers/table/PlaylistTrackTable.vue
@@ -8,6 +8,16 @@
       :no-data-text="noDataText"
       class="PlaylistTrackTable"
     >
+      <template #header.addedBy>
+        <v-icon
+          :size="16"
+          color="subtext"
+          title="追加したユーザー"
+        >
+          mdi-account
+        </v-icon>
+      </template>
+
       <template #header.duration>
         <v-icon
           :size="16"
@@ -115,7 +125,7 @@ export default Vue.extend({
       value: 'name',
     };
     const addedByColumn = {
-      text: 'ユーザー',
+      text: '',
       value: 'addedBy',
       width: 96,
       align: 'center' as const,

--- a/client/components/parts/table/PlaylistTrackTableRow.vue
+++ b/client/components/parts/table/PlaylistTrackTableRow.vue
@@ -30,7 +30,7 @@
 
       <td>
         <div :class="$style.Content">
-          <div class="g-ellipsis-text">
+          <div>
             <div
               :class="titleColor"
               class="g-ellipsis-text"
@@ -83,6 +83,19 @@
       </td>
 
       <td
+        v-if="collaborative"
+        :class="$style.PlaylistTrackTableRow__smallText"
+        class="text-center g-ellipsis-text"
+      >
+        <nuxt-link
+          :to="`/users/${item.addedBy.id}`"
+        >
+          {{ item.addedBy.display_name || item.addedBy.id }}
+        </nuxt-link>
+      </td>
+
+      <td
+        v-if="addedAt"
         :title="item.addedAt.title"
         :class="$style.PlaylistTrackTableRow__smallText"
         class="text-center"
@@ -181,6 +194,10 @@ export default Vue.extend({
     addedAt: {
       type: Boolean,
       default: true,
+    },
+    collaborative: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/client/components/parts/table/PlaylistTrackTableRow.vue
+++ b/client/components/parts/table/PlaylistTrackTableRow.vue
@@ -85,7 +85,7 @@
       <td
         v-if="collaborative"
         :class="$style.PlaylistTrackTableRow__smallText"
-        class="text-center g-ellipsis-text"
+        class="g-ellipsis-text"
       >
         <nuxt-link
           :to="`/users/${item.addedBy.id}`"
@@ -98,7 +98,6 @@
         v-if="addedAt"
         :title="item.addedAt.title"
         :class="$style.PlaylistTrackTableRow__smallText"
-        class="text-center"
       >
         <time
           v-if="item.addedAt.text"

--- a/client/scripts/converter/convertPlaylistTrackDetail.ts
+++ b/client/scripts/converter/convertPlaylistTrackDetail.ts
@@ -7,7 +7,7 @@ export const convertPlaylistTrackDetail = (
     offset?: number
   },
 ) => (
-  { track, added_at }: { track: SpotifyAPI.Track, added_at: string },
+  { track, added_at, added_by }: SpotifyAPI.PlaylistTrack & { track: SpotifyAPI.Track },
   index: number,
 ): App.PlaylistTrackDetail => {
   const detail = {
@@ -35,6 +35,7 @@ export const convertPlaylistTrackDetail = (
     releaseName: track.album.name,
     artworkList: track.album.images,
     addedAt: convertAddedAt(added_at),
+    addedBy: added_by,
   };
 
   return detail;

--- a/types/app/App.ts
+++ b/types/app/App.ts
@@ -37,6 +37,7 @@ export namespace App {
   export type PlaylistTrackDetail = TrackDetail & {
     type: 'track' | 'episode'
     addedAt: AddedAtInfo
+    addedBy: SpotifyAPI.UserData
   }
 
   export type TrackQueueInfo = {

--- a/types/app/SpotifyAPI.d.ts
+++ b/types/app/SpotifyAPI.d.ts
@@ -267,6 +267,7 @@ export namespace SpotifyAPI {
   }
   type PlaylistTrack = {
     added_at: string // timestamp
+    // @todo display_name など取得できないフィールドがある
     added_by: UserData
     is_local: boolean
     track: Track | null


### PR DESCRIPTION
## About

- close #207 
- ~~コラボプレイリストの場合は追加したユーザーのカラムを表示~~
- コラボプレイリストの追加したユーザーのカラムを追加
- 現状、プレイリストのトラック内の `added_by` プロパティからはユーザーの `display_name` がとれず、別途リクエストを送らないといけないのが面倒なのであとでやる
  - `PlaylistTrackTable` で `collaborative` 属性を指定すれば表示できるようにしてる